### PR TITLE
kazakh tests for new mappings

### DIFF
--- a/tests/data/script_samples/cyrillic.csv
+++ b/tests/data/script_samples/cyrillic.csv
@@ -21,3 +21,44 @@ tatar,"Татар халкы 1552 елдан соң : ‡b югалтулар һ
 turkmen,"Түркмен халкының гелип чыкышының дүнйә яйрайшының ве онуң дөвлетиниң тарыхының проблемалары : халкара ылмы конференцияның докладларының ве хабарларының тезислери, Ашгабат, 1993 й. 25-26 октябрь / редакторлар, Б.О. Шыхмырадов ... [et al.].","Tu̇rkmen khalkynyn︠g︡ gelip chykyshynyn︠g︡ du̇nĭă i︠a︡ĭraĭshynyn︠g︡ ve onun︠g︡ dȯvletinin︠g︡ tarykhynyn︠g︡ problemalary : khalkara ylmy konferent︠s︡ii︠a︡nyn︠g︡ dokladlarynyn︠g︡ ve khabarlarynyn︠g︡ tezisleri, Ashgabat, 1993 ĭ. 25-26 okti︠a︡brʹ / redaktorlar, B.O. Shykhmyradov ... [et al.].",,
 ukrainian,Децентралізація в Україні та її вплив на соціально-економічний розвиток територій,Det︠s︡entralizat︠s︡ii︠a︡ v Ukraïni ta ïï vplyv na sot︠s︡ialʹno-ekonomichnyĭ rozvytok terytoriĭ,,
 uzbek,Темур ва Улуғбек : даври тарихи / [бош муһаррир Аһмадали Асқаров ; масъул муһаррир Оқилхон Одилхон]. Тошкент : Қомуслар бош таһририяти,"Temur va Ulughbek : davri tarikhi / [bosh muḣarrir Aḣmadali Asqarov ; masʺul muḣarrir Oqilkhon Odilkhon]. Toshkent : Qomuslar bosh taḣririi︠a︡ti, [1996].",,
+kazakh,Қазақстан,Qazaqstan,,Translation: Kazakhstan
+kazakh,"Көз қорқақ, қол батыр.","Kȯz qorqaq, qol batyr.",,"Translation: Eyes are cowardly, hands are courageous."
+kazakh,"Білекті бірді жығар, білімді мыңды жығар.","Bīlektī bīrdī zhyghar, bīlīmdī myn︠g︡dy zhyghar.",,"Translation: Strong will defeat one, educated will defeat a thousand."
+kazakh,Жігітке жеті өнер де аз.,Zhīgītke zhetī ȯner de az.,,Translation: Mastery of even seven arts is not too much for a man.
+kazakh,"Батыр бір өледі, қорқақ мың өледі.","Batyr bīr ȯledī, qorqaq myn︠g︡ ȯledī.",,"Translation: A Batyr (definition: warrior aristocratic title earned by a war hero) dies once, a coward dies a thousand times."
+kazakh,Бауыржан Момышұлы,Bauyrzhan Momyshūly,,
+kazakh,Отан үшін отқа түс – күймейсің.,Otan u̇shīn otqa tu̇s – ku̇ĭmeĭsīn︠g︡.,,Translation: Jump into fire for Homeland and you won’t burn.
+kazakh,"Сабырлық алдында дұшпан сасады, Сабырсыздан береке қашады.","Sabyrlyq aldynda dūshpan sasady, Sabyrsyzdan bereke qashady.",,"Translation: An enemy loses themselves in front of calmness/composure, prosperity/grace runs away from absence of composure/calmness."
+kazakh,Мұхтар Әуезов,Mūkhtar Ăuezov,,Translation: 
+kazakh,"Қай істің болсын өнуіне үш шарт бар: ең әуелі - ниет керек, одан соң - күш керек, одан соң - тәртіп керек.","Qaĭ īstīn︠g︡ bolsyn ȯnuīne u̇sh shart bar: en︠g︡ ăuelī - niet kerek, odan son︠g︡ - ku̇sh kerek, odan son︠g︡ - tărtīp kerek.",,"Translation: Whatever endeveour you pursue  there are three conditions for it to thrive: first of all you need intention, then strength, then discipline. "
+kazakh,Ақпарат тарат тарапқа.,Aqparat tarat tarapqa,,Translation: Distribute the information in different directions.
+kazakh,Қазақ,Qazaq,,Translation: Kazakh
+kazakh,Қанағаттандырылмағандықтарыңыздан,Qanaghattandyrylmaghandyqtaryn︠g︡yzdan,,"Translation: One of the longest possible words in Kazakh language Due to you not getting satisfied; (here ""you"" is referring to multiple people in a polite form)"
+kazakh,Янцзы һәм Хуанхэде үй шөңгелі ық жағы тұщы. Фьючерсі объектив пе?,I︠A︡nt︠s︡zy ḣăm Khuankhėde u̇ĭ shȯn͡ggelī yq zhaghy tūshchy. Fʹi︠u︡chersī obʺektiv pe?,,"Translation: Some pangrams (a pangram contains all letter in a language's alphabet) Yangtze and Yellow rivers' side with houses, spikes and no wind is fresh (not salty). Are the futures objective"
+kazakh,"Щучинск съезіндегі өрт пе? Вагон-үй, аэромобиль һәм ұшақ фюзеляжы цехінен ғой. Білмейсің бе?","Shchuchinsk sʺezīndegī ȯrt pe? Vagon-u̇ĭ, aėromobilʹ ḣăm ūshaq fi︠u︡zeli͡azhy t︠s︡ekhīnen ghoĭ. Bīlmeĭsīn︠g︡ be?",,"Translation: A fire at the Shchuchinsk congress? It's from the carriage, airmobile and fuselage facility. Don't you know?"
+kazakh,"Доцент Пётр Щучинск съезінде, сәске ауа, ұйқылы-ояу, вагондағы оюлы жиһазда шалқая жатып, экрандағы фотоальбом мен хатқа өзгеше үңілді.","Dot︠s︡ent Pëtr Shchuchinsk sʺezīnde, săske aua, ūĭqyly-oi︠a︡u, vagondaghy oi︠u︡ly zhiḣazda shalqai͡a zhatyp, ėkrandaghy fotoalʹbom men khatqa ȯzgeshe u̇n︠g︡īldī.",,"Translation: At the Shchuchinsk congress Associate Professor Pëtr was lying half asleep on his back at noon on the ornamented furniture of the carriage, looking at a photo album and a letter on the screen."
+kazakh,автор,avtor,,Translation: author
+kazakh,редактор,redaktor,,Translation: editor
+kazakh,Баспа,Baspa,,Translation: Publishing house
+kazakh,Баспахана,Baspakhana,,Translation: Printer
+kazakh,баспагер/баспашы/басып шығарушы,baspager/baspashy/basyp shygharushy,,Translation: publisher/publisher/publisher
+kazakh,библиография,bibliografii︠a︡,,Translation: bibliography
+kazakh,мазмұндама,mazmūndama,,Translation: table of contents
+kazakh,Қорытыңды/дәйектеме/тұжырым,Qorytyn͡gdy/dăĭekteme/tūzhyrym,,Translation: Conclusion/conclusion/conclusion
+kazakh,қысқаша мазмұндама/баяндама,qysqasha mazmūndama/bai͡andama,,Translation: summary/summary
+kazakh,Алматы,Almaty,,Translation: city name
+kazakh,Астана,Astana,,Translation: city name
+kazakh,Көкшетау,Kȯkshetau,,Translation: city name
+kazakh,Семей,Semeĭ,,Translation: city name
+kazakh,Өскемен,Ȯskemen,,Translation: city name
+kazakh,Атырау,Atyrau,,Translation: city name
+kazakh,Ақтөбе,Aqtȯbe,,Translation: city name
+kazakh,Тараз,Taraz,,Translation: city name
+kazakh,Шымкент,Shymkent,,Translation: city name
+kazakh,Талдықорған,Taldyqorghan,,Translation: city name
+kazakh,Қызылжар,Qyzylzhar,,Translation: city name
+kazakh,Абай Құнанбайұлы,Abaĭ Qūnanbaĭūly,,Translation: Famous author name
+kazakh,Ыбырай Алтынсарин,Ybyraĭ Altynsarin,,Translation: Famous author name
+kazakh,Ахмет Байтұрсынұлы,Akhmet Baĭtūrsynūly,,Translation: Famous author name
+kazakh,Мағжан Жұмабайұлы,Maghzhan Zhūmabaĭūly,,Translation: Famous author name
+kazakh,Алихан Бөкейханұлы,Alikhan Bȯkeĭkhanūly,,Translation: Famous author name


### PR DESCRIPTION
These are new tests for Kazakh based on the new mappings provided by Nur Kinayat and Lana Soglasnova at University of Toronto. This should be merged after the new Kazakh mappings (attached, just for reference
[Bibframe inaccuracies_Kazakh (Cyrillic).docx](https://github.com/lcnetdev/scriptshifter/files/13429150/Bibframe.inaccuracies_Kazakh.Cyrillic.docx)
) are incorporated into Scriptshifter. 