### PR TITLE
Ignore MARC subfield markers.

### DIFF
--- a/scriptshifter/tables/data/_ignore_base.yml
+++ b/scriptshifter/tables/data/_ignore_base.yml
@@ -31,8 +31,10 @@ roman_to_script:
     - "X{1,3}I{,3}"
     - "X{1,3}I(V|X)"
     - "X{1,3}VI{,3}"
+    - "[\u2021$][0-9a-z] *"
 
 script_to_roman:
   ignore:
     - " "
-
+  ignore_ptn:
+    - "[\u2021$][0-9a-z] *"


### PR DESCRIPTION
Does not transliterate MARC sub-field markers such as $a, $b, ‡3, etc.