### PR TITLE
Update bulgarian.yml

### DIFF
--- a/scriptshifter/tables/data/bulgarian.yml
+++ b/scriptshifter/tables/data/bulgarian.yml
@@ -5,54 +5,34 @@ general:
 
 roman_to_script:
   map:
-    "G": "\u0413"
-    "g": "\u0433"
-    # this conversion shouldn't be needed, but does no harm
-    "ZH": "\u0416"
-    "Zh": "\u0416"
-    "zh": "\u0436"
-    "I\uFE20E\uFE21": "\u0462"
-    # this conversion shouldn't be needed, but does no harm
-    "I\uFE20e\uFE21": "\u0462"
-    # this conversion shouldn't be needed, but does no harm
-    # this conversion shouldn't be needed, but does no harm
-    "I": "\u0418"
-    "i\uFE20e\uFE21": "\u0463"
-    "i": "\u0438"
-    # this conversion shouldn't be needed, but does no harm
     "SHT": "\u0429"
     "Sht": "\u0429"
     "sht": "\u0449"
-    "T\uFE20S\uFE21": "\u0426"
-    # this conversion shouldn't be needed, but does no harm
-    "T\uFE20s\uFE21": "\u0426"
-    "t\uFE20s\uFE21": "\u0446"
-    "U\u0310": "\u046A"
+    "U\u0306": "\u042A"
+    # Mapping from precomposed non-MARC-8 Latin equivalent
+    "\u016C": "\u042A"
     "u\u0306": "\u044A"
+    # Mapping from precomposed non-MARC-8 Latin equivalent
+    "\u016D": "\u044A"
+    "U\u0310": "\u046A"
     "u\u0310": "\u046B"
     # this conversion is ambiguous - \u042A is also theoretically possible
     "\u02BA": "\u044A"
+    # upper case hard sign is unlikely to occur
+    "\u02BA\u0332": "\u042A"
 
 script_to_roman:
   map:
-    "\u044C": ""
-    "\u042C": ""
-    "\u044A": ""
-    "\u042A%": ""  # Final
-    "\u042A": "u\u0306"
-    "\u0413": "G"
-    "\u0433": "g"
-    "\u0416": "Zh"
-    "\u0436": "zh"
-    "\u0462": "I\uFE20E\uFE21"
-    "\u0418": "I"
-    "\u0463": "i\uFE20e\uFE21"
-    "\u0438": "i"
     "\u0429": "Sht"
+    "\u042A": "U\u0306"
+    # Capital letter hard sign at the end of a word (rare)
+    "\u042A%": "\u02BA\u0332"
+    "\u042C": "\u02B9\u0332"
     "\u0449": "sht"
-    "\u0426": "T\uFE20S\uFE21"
-    "\u0446": "t\uFE20s\uFE21"
+    "\u044A": "u\u0306"
+    # Small letter hard sign at the end of a word (rare)
+    "\u044A%": "\u02BA"
+    "\u044C": "\u02B9"
     "\u046A": "U\u0310"
     "\u046B": "u\u0310"
-    "\u042A": "u\u016C"
-    "\u044A": "u\u016D"
+    


### PR DESCRIPTION
One thing I should mention is that the change in the logical operator “%” to the end of the string still does not cause ScriptShifter to convert the Cyrillic character “\u044A%” to “\u02BA” at the end of a string. I don’t know why it won’t work. It may be something in ScriptShifter’s logic that Stefano can figure out.

I adjusted the Bulgarian_yml file to correct, or I should say “enhance” the exceptional mapping for the Cyrillic letter “Ъ/ъ”. For almost all Cyrillic based languages this letter pair map to the “hard sign” (prime) \u02BA but for Bulgarian, the letters are mapped to the Latin U/u with combining breve. The problem here, and elsewhere, was that the Latin side of the mapping was referencing Unicode precomposed Latin letters Ŭ/ŭ, that is which have completely different Unicode character values. It’s no wonder they weren’t converting properly. This problem is widespread in that, whenever someone has a Latin script base letter followed by a combining diacritical mark of some kind, it could also be represented by a single precomposed Latin script character. I discussed this problem with Sally. I think Stefano may be able to solve the problem more globally by adding a normalization process to the Latin side. The Voyager system automatically normalizes most precomposed Latin script letters to their base letter followed by a combining character. NOTE: Not all Latin letter with combining character(s) can be represented by a precomposed Unicode character. The MARC-8 and Unicode combining characters allow for what we’ve called an “open repertoire” of possible combinations. The Unicode Consortium added hundreds of precomposed letters with diacritics, especially within the Latin, Cyrillic, and Greek repertoires. Despite the richness of Unicode, some combinations are missing. For example, the “0̇/ȯ” and “U̇/u̇” (letters O/o and U/u with combining dot above) can only be encoded with the Latin base letters followed by the combining dot above. There are no precomposed Latin characters for these combinations. MANY of the Cyrillic-based non-Slavic languages have special O/o and U/u pairs that have been mapped to “0̇/ȯ” and “U̇/u̇”. There are other unusual combinations of Latin base letters with combining marks specified in the ALA-LC Romanization Tables that are NOT represented by precomposed Unicode characters. If we were developing the ALA-LC transliteration schemes today we might limit our choice of modified Latin letters to those in Unicode, but we can’t change our legacy data easily to that new approach. So, the problem will have to be dealt with someone, perhaps by partial fixes.

-- @RandyBarry 
