### PR TITLE
Automate updating of script table doc.

### DIFF
--- a/doc/gen_script_table_doc.py
+++ b/doc/gen_script_table_doc.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import sys
+from os import path
+
+DOCROOT = path.dirname(__file__)
+
+sys.path.append(path.dirname(DOCROOT))
+from scriptshifter.tables import list_tables
+
+with open(path.join(DOCROOT, "supported_scripts_template.md"), "r") as fh:
+    tpl_data = fh.read()
+
+with open(path.join(DOCROOT, "supported_scripts.md"), "w") as fh:
+    fh.write(tpl_data)
+
+    for name, data in list_tables().items():
+        fh.write(
+            f"[{name}](../scriptshifter/tables/data/{name}.yml) | "
+            f"{data['label']} | "
+        )
+        if "alias_of" in data:
+            fh.write(f"- | - | {data['alias_of']}\n")
+        else:
+            fh.write(
+                f"{'Y' if data.get('has_r2s', False) else 'N'} | "
+                f"{'Y' if data.get('has_s2r', False) else 'N'} | -\n"
+            )

--- a/doc/supported_scripts.md
+++ b/doc/supported_scripts.md
@@ -2,12 +2,8 @@
 
 Below are the supported scripts, and supported directionality of those scripts, in ScriptShifter.
 
-The "status" value may be *stable*, *beta*, *alpha*, or blank (i.e. empty).  "Stable" means the mapping 
-is maintained within ScriptShifter, has been tested, and is in use.  "Beta" or "alpha" represent mappings
-that are in some form of development and/or testing, with "beta" being more mature than "alpha" in this
-regard.  If the column is 'blank,' transliteration of the script is available in ScriptShifter from a
-third-party library.
-
+"Alias of" means that the script table is the same as the table indicated, only
+under a different name.
 
 |	Mapping file |  Script Name  |  Roman-to-script  |  Script-to-roman | Alias of
 |  -------- | ------- | ------- | ------- | ------- |
@@ -16,25 +12,25 @@ third-party library.
 [abkhaz_cyrillic](../scriptshifter/tables/data/abkhaz_cyrillic.yml) | Abkhaz (Cyrillic) | Y | Y | -
 [adygei_cyrillic](../scriptshifter/tables/data/adygei_cyrillic.yml) | Adygei (Cyrillic) | Y | Y | -
 [altai_cyrillic](../scriptshifter/tables/data/altai_cyrillic.yml) | Altai (Cyrillic) | Y | Y | -
-[amharic](../scriptshifter/tables/data/amharic.yml) | Amharic | - | - | ethiopic_generic
+[amharic](../scriptshifter/tables/data/amharic.yml) | Amharic | N | N | -
 [ethiopic_generic](../scriptshifter/tables/data/ethiopic_generic.yml) | Ethiopic (Generic) | Y | Y | -
 [arabic](../scriptshifter/tables/data/arabic.yml) | Arabic | Y | Y | -
-[argobba_ethiopic](../scriptshifter/tables/data/argobba_ethiopic.yml) | Argobba (Ethiopic) | - | - | ethiopic_generic
+[argobba_ethiopic](../scriptshifter/tables/data/argobba_ethiopic.yml) | Argobba (Ethiopic) | N | N | -
 [armenian](../scriptshifter/tables/data/armenian.yml) | Armenian | Y | Y | -
 [assamese](../scriptshifter/tables/data/assamese.yml) | Assamese | Y | Y | -
 [avaric_cyrillic](../scriptshifter/tables/data/avaric_cyrillic.yml) | Avaric (Cyrillic) | Y | Y | -
-[awadhi_devanagari](../scriptshifter/tables/data/awadhi_devanagari.yml) | Awadhi (Devanagari) | - | - | devanagari_generic
+[awadhi_devanagari](../scriptshifter/tables/data/awadhi_devanagari.yml) | Awadhi (Devanagari) | N | N | -
 [devanagari_generic](../scriptshifter/tables/data/devanagari_generic.yml) | Devanagari (Generic) | Y | Y | -
 [azerbaijani_cyrillic](../scriptshifter/tables/data/azerbaijani_cyrillic.yml) | Azerbaijani (Cyrillic) | Y | Y | -
-[balkar_cyrillic](../scriptshifter/tables/data/balkar_cyrillic.yml) | Balkar (Cyrillic) | - | - | cyrillic_generic
+[balkar_cyrillic](../scriptshifter/tables/data/balkar_cyrillic.yml) | Balkar (Cyrillic) | N | N | -
 [cyrillic_generic](../scriptshifter/tables/data/cyrillic_generic.yml) | Cyrillic (Generic) | Y | Y | -
 [bashkir_cyrillic](../scriptshifter/tables/data/bashkir_cyrillic.yml) | Bashkir (Cyrillic) | Y | Y | -
 [belarusian](../scriptshifter/tables/data/belarusian.yml) | Belarusian | Y | Y | -
 [bengali](../scriptshifter/tables/data/bengali.yml) | Bengali | Y | Y | -
-[bihari_devanagari](../scriptshifter/tables/data/bihari_devanagari.yml) | Bihari (Devanagari) | - | - | devanagari_generic
+[bihari_devanagari](../scriptshifter/tables/data/bihari_devanagari.yml) | Bihari (Devanagari) | N | N | -
 [bodo_bengali](../scriptshifter/tables/data/bodo_bengali.yml) | Bodo (Bengali) | Y | Y | -
 [bodo_devanagari](../scriptshifter/tables/data/bodo_devanagari.yml) | Bodo (Devanagari) | Y | Y | -
-[braj_devanagari](../scriptshifter/tables/data/braj_devanagari.yml) | Braj (Devanagari) | - | - | devanagari_generic
+[braj_devanagari](../scriptshifter/tables/data/braj_devanagari.yml) | Braj (Devanagari) | N | N | -
 [bulgarian](../scriptshifter/tables/data/bulgarian.yml) | Bulgarian | Y | Y | -
 [buriat_cyrillic](../scriptshifter/tables/data/buriat_cyrillic.yml) | Buriat (Cyrillic) | Y | Y | -
 [buriat_mongol_bichig](../scriptshifter/tables/data/buriat_mongol_bichig.yml) | Buriat (Mongol bichig) | Y | Y | -
@@ -46,33 +42,33 @@ third-party library.
 [church_slavonic](../scriptshifter/tables/data/church_slavonic.yml) | Church Slavonic | Y | Y | -
 [chuvash_cyrillic](../scriptshifter/tables/data/chuvash_cyrillic.yml) | Chuvash (Cyrillic) | Y | Y | -
 [coptic](../scriptshifter/tables/data/coptic.yml) | Coptic | Y | Y | -
-[dargwa_cyrillic](../scriptshifter/tables/data/dargwa_cyrillic.yml) | Dargwa (Cyrillic) | - | - | cyrillic_generic
+[dargwa_cyrillic](../scriptshifter/tables/data/dargwa_cyrillic.yml) | Dargwa (Cyrillic) | N | N | -
 [divehi_thaana](../scriptshifter/tables/data/divehi_thaana.yml) | Divehi (Thaana) | Y | Y | -
 [dogri_devanagari](../scriptshifter/tables/data/dogri_devanagari.yml) | Dogri (Devanagari) | Y | Y | -
 [dungan_cyrillic](../scriptshifter/tables/data/dungan_cyrillic.yml) | Dungan (Cyrillic) | Y | Y | -
-[dzongkha_tibetan](../scriptshifter/tables/data/dzongkha_tibetan.yml) | Dzongkha (Tibetan) | - | - | tibetan
+[dzongkha_tibetan](../scriptshifter/tables/data/dzongkha_tibetan.yml) | Dzongkha (Tibetan) | N | N | -
 [tibetan](../scriptshifter/tables/data/tibetan.yml) | Tibetan | Y | Y | -
 [even-evenki_cyrillic](../scriptshifter/tables/data/even-evenki_cyrillic.yml) | Even/Evenki (Cyrillic) | Y | Y | -
 [fula_adlam](../scriptshifter/tables/data/fula_adlam.yml) | Fula (ADLaM) | Y | Y | -
 [gagauz_cyrillic](../scriptshifter/tables/data/gagauz_cyrillic.yml) | Gagauz (Cyrillic) | Y | Y | -
 [georgian](../scriptshifter/tables/data/georgian.yml) | Georgian | Y | Y | -
-[gilyak_cyrillic](../scriptshifter/tables/data/gilyak_cyrillic.yml) | Gilyak (Cyrillic) | - | - | cyrillic_generic
+[gilyak_cyrillic](../scriptshifter/tables/data/gilyak_cyrillic.yml) | Gilyak (Cyrillic) | N | N | -
 [glagolitic](../scriptshifter/tables/data/glagolitic.yml) | Glagolitic | Y | Y | -
 [greek_classical](../scriptshifter/tables/data/greek_classical.yml) | Greek (Classical) | Y | Y | -
 [greek_modern](../scriptshifter/tables/data/greek_modern.yml) | Greek (Modern) | Y | Y | -
 [gujarati](../scriptshifter/tables/data/gujarati.yml) | Gujarati | Y | Y | -
-[gurage_ethiopic](../scriptshifter/tables/data/gurage_ethiopic.yml) | Gurage (Ethiopic) | - | - | ethiopic_generic
+[gurage_ethiopic](../scriptshifter/tables/data/gurage_ethiopic.yml) | Gurage (Ethiopic) | N | N | -
 [gurmukhi_generic](../scriptshifter/tables/data/gurmukhi_generic.yml) | Gurmukhi (generic) | Y | Y | -
 [hebrew](../scriptshifter/tables/data/hebrew.yml) | Hebrew | N | Y | -
-[hindi](../scriptshifter/tables/data/hindi.yml) | Hindi (Devanagari) | - | - | devanagari_generic
-[ingush_cyrillic](../scriptshifter/tables/data/ingush_cyrillic.yml) | Ingush (Cyrillic) | - | - | cyrillic_generic
-[inuit_cyrillic](../scriptshifter/tables/data/inuit_cyrillic.yml) | Inuit (Cyrillic) | - | - | cyrillic_generic
+[hindi](../scriptshifter/tables/data/hindi.yml) | Hindi (Devanagari) | N | N | -
+[ingush_cyrillic](../scriptshifter/tables/data/ingush_cyrillic.yml) | Ingush (Cyrillic) | N | N | -
+[inuit_cyrillic](../scriptshifter/tables/data/inuit_cyrillic.yml) | Inuit (Cyrillic) | N | N | -
 [inuktitut](../scriptshifter/tables/data/inuktitut.yml) | Inuktitut | Y | Y | -
-[kabardian_cyrillic](../scriptshifter/tables/data/kabardian_cyrillic.yml) | Kabardian (Cyrillic) | - | - | cyrillic_generic
+[kabardian_cyrillic](../scriptshifter/tables/data/kabardian_cyrillic.yml) | Kabardian (Cyrillic) | N | N | -
 [kalmyk_cyrillic](../scriptshifter/tables/data/kalmyk_cyrillic.yml) | Kalmyk (Cyrillic) | Y | Y | -
 [kalmyk_tod](../scriptshifter/tables/data/kalmyk_tod.yml) | Kalmyk (Tod) | Y | Y | -
 [kannada](../scriptshifter/tables/data/kannada.yml) | Kannada | Y | Y | -
-[kara-kalpak_cyrillic](../scriptshifter/tables/data/kara-kalpak_cyrillic.yml) | Kara-Kalpak (Cyrillic) | - | - | cyrillic_generic
+[kara-kalpak_cyrillic](../scriptshifter/tables/data/kara-kalpak_cyrillic.yml) | Kara-Kalpak (Cyrillic) | N | N | -
 [karachay-balkar_cyrillic](../scriptshifter/tables/data/karachay-balkar_cyrillic.yml) | Karachay-Balkar  (Cyrillic) | Y | Y | -
 [karelian_cyrillic](../scriptshifter/tables/data/karelian_cyrillic.yml) | Karelian  (Cyrillic) | Y | Y | -
 [kazakh_cyrillic](../scriptshifter/tables/data/kazakh_cyrillic.yml) | Kazakh (Cyrillic) | Y | Y | -
@@ -81,57 +77,57 @@ third-party library.
 [khmer](../scriptshifter/tables/data/khmer.yml) | Khmer | Y | Y | -
 [komi_cyrillic](../scriptshifter/tables/data/komi_cyrillic.yml) | Komi (Cyrillic) | Y | Y | -
 [komi-permyak_cyrillic](../scriptshifter/tables/data/komi-permyak_cyrillic.yml) | Komi-Permyak (Cyrillic) | Y | Y | -
-[konkani_devanagari](../scriptshifter/tables/data/konkani_devanagari.yml) | Konkani (Devanagari) | - | - | devanagari_generic
-[konkani_kannada](../scriptshifter/tables/data/konkani_kannada.yml) | Konkani (Kannada) | - | - | kannada
+[konkani_devanagari](../scriptshifter/tables/data/konkani_devanagari.yml) | Konkani (Devanagari) | N | N | -
+[konkani_kannada](../scriptshifter/tables/data/konkani_kannada.yml) | Konkani (Kannada) | N | N | -
 [korean_names](../scriptshifter/tables/data/korean_names.yml) | Korean (last + first names only) | N | Y | -
 [korean_nonames](../scriptshifter/tables/data/korean_nonames.yml) | Korean | N | Y | -
 [koryak_cyrillic](../scriptshifter/tables/data/koryak_cyrillic.yml) | Koryak (Cyrillic) | Y | Y | -
-[kumyk_cyrillic](../scriptshifter/tables/data/kumyk_cyrillic.yml) | Kumyk (Cyrillic) | - | - | cyrillic_generic
+[kumyk_cyrillic](../scriptshifter/tables/data/kumyk_cyrillic.yml) | Kumyk (Cyrillic) | N | N | -
 [kurdish_arabic](../scriptshifter/tables/data/kurdish_arabic.yml) | Kurdish (Arabic) | Y | N | -
 [kurdish_cyrillic](../scriptshifter/tables/data/kurdish_cyrillic.yml) | Kurdish (Cyrillic) | Y | Y | -
 [kyrgyz_cyrillic](../scriptshifter/tables/data/kyrgyz_cyrillic.yml) | Kyrgyz (Cyrillic) | Y | Y | -
-[lak_cyrillic](../scriptshifter/tables/data/lak_cyrillic.yml) | Lak (Cyrillic) | - | - | cyrillic_generic
-[lahnda_gurmukhi](../scriptshifter/tables/data/lahnda_gurmukhi.yml) | Lahnda (Gurmukhi) | - | - | gurmukhi_generic
+[lak_cyrillic](../scriptshifter/tables/data/lak_cyrillic.yml) | Lak (Cyrillic) | N | N | -
+[lahnda_gurmukhi](../scriptshifter/tables/data/lahnda_gurmukhi.yml) | Lahnda (Gurmukhi) | N | N | -
 [lepcha](../scriptshifter/tables/data/lepcha.yml) | Lepcha | Y | Y | -
-[lezghian_cyrillic](../scriptshifter/tables/data/lezghian_cyrillic.yml) | Lezghian (Cyrillic) | - | - | cyrillic_generic
+[lezghian_cyrillic](../scriptshifter/tables/data/lezghian_cyrillic.yml) | Lezghian (Cyrillic) | N | N | -
 [limbu](../scriptshifter/tables/data/limbu.yml) | Limbu | Y | Y | -
 [lithuanian_cyrillic](../scriptshifter/tables/data/lithuanian_cyrillic.yml) | Lithuanian (Cyrillic) | Y | Y | -
 [macedonian](../scriptshifter/tables/data/macedonian.yml) | Macedonian | Y | Y | -
-[maithili_devanagari](../scriptshifter/tables/data/maithili_devanagari.yml) | Maithili (Devanagari) | - | - | devanagari_generic
+[maithili_devanagari](../scriptshifter/tables/data/maithili_devanagari.yml) | Maithili (Devanagari) | N | N | -
 [malayalam](../scriptshifter/tables/data/malayalam.yml) | Malayalam | Y | Y | -
 [manchu](../scriptshifter/tables/data/manchu.yml) | Manchu | Y | Y | -
 [manipuri_bengali](../scriptshifter/tables/data/manipuri_bengali.yml) | Manipuri (Bengali) | Y | Y | -
 [manipuri_meitei](../scriptshifter/tables/data/manipuri_meitei.yml) | Manipuri (Meitei) | Y | Y | -
 [mansi_cyrillic](../scriptshifter/tables/data/mansi_cyrillic.yml) | Mansi (Cyrillic) | Y | Y | -
 [marathi_devanagari](../scriptshifter/tables/data/marathi_devanagari.yml) | Marathi (Devanagari) | Y | Y | -
-[mari_cyrillic](../scriptshifter/tables/data/mari_cyrillic.yml) | Mari (Cyrillic) | - | - | cyrillic_generic
+[mari_cyrillic](../scriptshifter/tables/data/mari_cyrillic.yml) | Mari (Cyrillic) | N | N | -
 [moldovan_cyrillic](../scriptshifter/tables/data/moldovan_cyrillic.yml) | Moldovan (Cyrillic) | Y | Y | -
 [mongolian_cyrillic](../scriptshifter/tables/data/mongolian_cyrillic.yml) | Mongolian (Cyrillic) | Y | Y | -
 [mongolian_mongol_bichig](../scriptshifter/tables/data/mongolian_mongol_bichig.yml) | Mongolian (Mongol bichig) | Y | Y | -
 [montenegrin_cyrillic](../scriptshifter/tables/data/montenegrin_cyrillic.yml) | Montenegrin (Cyrillic) | Y | Y | -
 [mordvin_cyrillic](../scriptshifter/tables/data/mordvin_cyrillic.yml) | Mordvin (Cyrillic) | Y | Y | -
-[moroccan_tamazight](../scriptshifter/tables/data/moroccan_tamazight.yml) | Moroccan Tamazight | - | - | tifinagh_generic
+[moroccan_tamazight](../scriptshifter/tables/data/moroccan_tamazight.yml) | Moroccan Tamazight | N | N | -
 [tifinagh_generic](../scriptshifter/tables/data/tifinagh_generic.yml) | Tifinagh (Generic) | Y | Y | -
-[nanai_cyrillic](../scriptshifter/tables/data/nanai_cyrillic.yml) | Nanai (Cyrillic) | - | - | cyrillic_generic
+[nanai_cyrillic](../scriptshifter/tables/data/nanai_cyrillic.yml) | Nanai (Cyrillic) | N | N | -
 [nenets_cyrillic](../scriptshifter/tables/data/nenets_cyrillic.yml) | Nenets (Cyrillic) | Y | Y | -
-[nepali_devanagari](../scriptshifter/tables/data/nepali_devanagari.yml) | Nepali (Devanagari) | - | - | devanagari_generic
-[newari_devanagari](../scriptshifter/tables/data/newari_devanagari.yml) | Newari (Devanagari) | - | - | devanagari_generic
-[nivkh_cyrillic](../scriptshifter/tables/data/nivkh_cyrillic.yml) | Nivkh (Cyrillic) | - | - | cyrillic_generic
-[nogai_cyrillic](../scriptshifter/tables/data/nogai_cyrillic.yml) | Nogai (Cyrillic) | - | - | cyrillic_generic
+[nepali_devanagari](../scriptshifter/tables/data/nepali_devanagari.yml) | Nepali (Devanagari) | N | N | -
+[newari_devanagari](../scriptshifter/tables/data/newari_devanagari.yml) | Newari (Devanagari) | N | N | -
+[nivkh_cyrillic](../scriptshifter/tables/data/nivkh_cyrillic.yml) | Nivkh (Cyrillic) | N | N | -
+[nogai_cyrillic](../scriptshifter/tables/data/nogai_cyrillic.yml) | Nogai (Cyrillic) | N | N | -
 [odia](../scriptshifter/tables/data/odia.yml) | Odia | Y | Y | -
 [ossetic_cyrillic](../scriptshifter/tables/data/ossetic_cyrillic.yml) | Ossetic (Cyrillic) | Y | Y | -
-[pahari_devanagari](../scriptshifter/tables/data/pahari_devanagari.yml) | Pahari (Devanagari) | - | - | devanagari_generic
-[pali_bengali](../scriptshifter/tables/data/pali_bengali.yml) | Pali (Bengali) | - | - | bengali
-[pali_devanagari](../scriptshifter/tables/data/pali_devanagari.yml) | Pali (Devanagari) | - | - | devanagari_generic
-[pali_sinhala](../scriptshifter/tables/data/pali_sinhala.yml) | Pali (Sinhala) | - | - | sinhala
+[pahari_devanagari](../scriptshifter/tables/data/pahari_devanagari.yml) | Pahari (Devanagari) | N | N | -
+[pali_bengali](../scriptshifter/tables/data/pali_bengali.yml) | Pali (Bengali) | N | N | -
+[pali_devanagari](../scriptshifter/tables/data/pali_devanagari.yml) | Pali (Devanagari) | N | N | -
+[pali_sinhala](../scriptshifter/tables/data/pali_sinhala.yml) | Pali (Sinhala) | N | N | -
 [sinhala](../scriptshifter/tables/data/sinhala.yml) | Sinhala | Y | Y | -
 [panjabi_gurmukhi](../scriptshifter/tables/data/panjabi_gurmukhi.yml) | Panjabi (Gurmukhi) | Y | Y | -
-[permyak_cyrillic](../scriptshifter/tables/data/permyak_cyrillic.yml) | Permyak (Cyrillic) | - | - | komi-permyak_cyrillic
+[permyak_cyrillic](../scriptshifter/tables/data/permyak_cyrillic.yml) | Permyak (Cyrillic) | N | N | -
 [persian](../scriptshifter/tables/data/persian.yml) | Persian | Y | N | -
 [prakrit_devanagari](../scriptshifter/tables/data/prakrit_devanagari.yml) | Prakrit (Devanagari) | Y | Y | -
 [pushto](../scriptshifter/tables/data/pushto.yml) | Pushto | Y | N | -
-[rajasthani_devanagari](../scriptshifter/tables/data/rajasthani_devanagari.yml) | Rajasthani (Devanagari) | - | - | devanagari_generic
-[romani_cyrillic](../scriptshifter/tables/data/romani_cyrillic.yml) | Romani (Cyrillic) | - | - | cyrillic_generic
+[rajasthani_devanagari](../scriptshifter/tables/data/rajasthani_devanagari.yml) | Rajasthani (Devanagari) | N | N | -
+[romani_cyrillic](../scriptshifter/tables/data/romani_cyrillic.yml) | Romani (Cyrillic) | N | N | -
 [romanian_cyrillic](../scriptshifter/tables/data/romanian_cyrillic.yml) | Romanian (Cyrillic) | Y | Y | -
 [russian](../scriptshifter/tables/data/russian.yml) | Russian | Y | Y | -
 [sami_cyrillic](../scriptshifter/tables/data/sami_cyrillic.yml) | Sami (Cyrillic) | Y | Y | -
@@ -141,26 +137,26 @@ third-party library.
 [serbian](../scriptshifter/tables/data/serbian.yml) | Serbian | Y | Y | -
 [shor_cyrillic](../scriptshifter/tables/data/shor_cyrillic.yml) | Shor (Cyrillic) | Y | Y | -
 [sindhi_arabic](../scriptshifter/tables/data/sindhi_arabic.yml) | Sindhi (Arabic) | Y | N | -
-[sindhi_gurmukhi](../scriptshifter/tables/data/sindhi_gurmukhi.yml) | Sindhi (Gurmukhi) | - | - | gurmukhi_generic
+[sindhi_gurmukhi](../scriptshifter/tables/data/sindhi_gurmukhi.yml) | Sindhi (Gurmukhi) | N | N | -
 [syriac_cyrillic](../scriptshifter/tables/data/syriac_cyrillic.yml) | Syriac (Cyrillic) | Y | Y | -
-[tabasaran_cyrillic](../scriptshifter/tables/data/tabasaran_cyrillic.yml) | Tabasaran (Cyrillic) | - | - | cyrillic_generic
+[tabasaran_cyrillic](../scriptshifter/tables/data/tabasaran_cyrillic.yml) | Tabasaran (Cyrillic) | N | N | -
 [tajik_cyrillic](../scriptshifter/tables/data/tajik_cyrillic.yml) | Tajik (Cyrillic) | Y | Y | -
 [tamashek](../scriptshifter/tables/data/tamashek.yml) | Tamashek | Y | Y | -
-[tamazight_moroccan](../scriptshifter/tables/data/tamazight_moroccan.yml) | Tamazight (Moroccan) | - | - | tifinagh_generic
+[tamazight_moroccan](../scriptshifter/tables/data/tamazight_moroccan.yml) | Tamazight (Moroccan) | N | N | -
 [tamil](../scriptshifter/tables/data/tamil.yml) | Tamil | Y | Y | -
 [tamil_brahmi](../scriptshifter/tables/data/tamil_brahmi.yml) | Tamil Brahmi | Y | Y | -
 [tamil_extended](../scriptshifter/tables/data/tamil_extended.yml) | Tamil (extended) | Y | Y | -
-[tat_cyrillic](../scriptshifter/tables/data/tat_cyrillic.yml) | Tat (Cyrillic) | - | - | cyrillic_generic
+[tat_cyrillic](../scriptshifter/tables/data/tat_cyrillic.yml) | Tat (Cyrillic) | N | N | -
 [tatar_cyrillic](../scriptshifter/tables/data/tatar_cyrillic.yml) | Tatar (Cyrillic) | Y | Y | -
 [tatar-kryashen_cyrillic](../scriptshifter/tables/data/tatar-kryashen_cyrillic.yml) | Tatar-Kryashen (Cyrillic) | Y | Y | -
 [telugu](../scriptshifter/tables/data/telugu.yml) | Telugu | Y | Y | -
 [thai](../scriptshifter/tables/data/thai.yml) | Thai | N | Y | -
 [tibetan_2015_r2r](../scriptshifter/tables/data/tibetan_2015_r2r.yml) | Tibetan (ñ,ṅ,ś,ź to ny,ng,sh,zh only) | Y | N | -
-[tigre_ethiopic](../scriptshifter/tables/data/tigre_ethiopic.yml) | Tigre (Ethiopic) | - | - | ethiopic_generic
-[tigrinya_ethiopic](../scriptshifter/tables/data/tigrinya_ethiopic.yml) | Tigrinya (Ethiopic) | - | - | ethiopic_generic
+[tigre_ethiopic](../scriptshifter/tables/data/tigre_ethiopic.yml) | Tigre (Ethiopic) | N | N | -
+[tigrinya_ethiopic](../scriptshifter/tables/data/tigrinya_ethiopic.yml) | Tigrinya (Ethiopic) | N | N | -
 [turkmen_cyrillic](../scriptshifter/tables/data/turkmen_cyrillic.yml) | Turkmen (Cyrillic) | Y | Y | -
-[tuvinian_cyrillic](../scriptshifter/tables/data/tuvinian_cyrillic.yml) | Tuvinian (Cyrillic) | - | - | cyrillic_generic
-[udekhe_cyrillic](../scriptshifter/tables/data/udekhe_cyrillic.yml) | Udekhe (Cyrillic) | - | - | cyrillic_generic
+[tuvinian_cyrillic](../scriptshifter/tables/data/tuvinian_cyrillic.yml) | Tuvinian (Cyrillic) | N | N | -
+[udekhe_cyrillic](../scriptshifter/tables/data/udekhe_cyrillic.yml) | Udekhe (Cyrillic) | N | N | -
 [udmurt_cyrillic](../scriptshifter/tables/data/udmurt_cyrillic.yml) | Udmurt (Cyrillic) | Y | Y | -
 [uighur_arabic](../scriptshifter/tables/data/uighur_arabic.yml) | Uighur (Arabic) | Y | Y | -
 [uighur_cyrillic](../scriptshifter/tables/data/uighur_cyrillic.yml) | Uighur (Cyrillic) | Y | Y | -

--- a/doc/supported_scripts.md
+++ b/doc/supported_scripts.md
@@ -9,103 +9,164 @@ regard.  If the column is 'blank,' transliteration of the script is available in
 third-party library.
 
 
-|	Mapping file |  Script Name  |  Roman-to-script  |  Script-to-roman  |  Status  |  Remarks
-|  -------- | ------- | ------- | ------- | ------- | ------- |
-|  [abkhaz_cyrillic](../scriptshifter/tables/data/abkhaz_cyrillic.yml)  |  Abkhaz (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [altai_cyrillic](../scriptshifter/tables/data/altai_cyrillic.yml)  |  Altai (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [arabic](../scriptshifter/tables/data/arabic.yml)  |  Arabic  |  Y  |  Y  |  stable (R2S)  |  Arabic R2S using a conversion table and S2R using a 3rd party library.
-|  [armenian](../scriptshifter/tables/data/armenian.yml)  |  Armenian  |  Y  |  Y  |  stable  |  
-|  [asian_cyrillic](../scriptshifter/tables/data/asian_cyrillic.yml)  |  Asian Cyrillic  |  Y  |  Y  |  stable  |  
-|  [assamese](../scriptshifter/tables/data/assamese.yml)  |  Assamese  |  Y  |  Y  |    |  
-|  [azerbaijani_cyrillic](../scriptshifter/tables/data/azerbaijani_cyrillic.yml)  |  Azerbaijani (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [bashkir_cyrillic](../scriptshifter/tables/data/bashkir_cyrillic.yml)  |  Bashkir (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [belarusian](../scriptshifter/tables/data/belarusian.yml)  |  Belarusian  |  Y  |  Y  |  stable  |  
-|  [bengali](../scriptshifter/tables/data/bengali.yml)  |  Bengali  |  Y  |  Y  |    |  
-|  [bulgarian](../scriptshifter/tables/data/bulgarian.yml)  |  Bulgarian  |  Y  |  Y  |  stable  |  
-|  [buriat_cyrillic](../scriptshifter/tables/data/buriat_cyrillic.yml)  |  Buriat (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [burmese](../scriptshifter/tables/data/burmese.yml)  |  Burmese (Myanmar)  |  Y  |  Y  |    |  
-|  [chinese](../scriptshifter/tables/data/chinese.yml)  |  Chinese (Hanzi)  |  N  |  Y  |  stable  |  
-|  [chukchi_cyrillic](../scriptshifter/tables/data/chukchi_cyrillic.yml)  |  Chukchi (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [church_slavonic](../scriptshifter/tables/data/church_slavonic.yml)  |  Church Slavonic  |  Y  |  Y  |  stable  |  
-|  [chuvash_cyrillic](../scriptshifter/tables/data/chuvash_cyrillic.yml)  |  Chuvash (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [devanagari](../scriptshifter/tables/data/devanagari.yml)  |  Devanagari  |  Y  |  Y  |    |  
-|  [divehi_thaana](../scriptshifter/tables/data/divehi_thaana.yml)  |  Divehi (Thaana)  |  Y  |  Y  |  stable  |  
-|  [dogri_devanagari](../scriptshifter/tables/data/dogri_devanagari.yml)  |  Dogri (Devanagari)  |  Y  |  Y  |    |  
-|  [dungan_cyrillic](../scriptshifter/tables/data/dungan_cyrillic.yml)  |  Dungan (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [ethiopic](../scriptshifter/tables/data/ethiopic.yml)  |  Ethiopic (Amharic)  |  Y  |  Y  |  beta  |  
-|  [even-evenki_cyrillic](../scriptshifter/tables/data/even-evenki_cyrillic.yml)  |  Even/Evenki (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [gagauz_cyrillic](../scriptshifter/tables/data/gagauz_cyrillic.yml)  |  Gagauz (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [georgian](../scriptshifter/tables/data/georgian.yml)  |  Georgian  |  Y  |  Y  |  stable  |  
-|  [greek_classical](../scriptshifter/tables/data/greek_classical.yml)  |  Greek (classical)  |  Y  |  Y  |  stable  |  
-|  [greek_modern](../scriptshifter/tables/data/greek_modern.yml)  |  Greek (modern)  |  Y  |  Y  |  stable  |  
-|  [gujarati](../scriptshifter/tables/data/gujarati.yml)  |  Gujarati  |  Y  |  Y  |    |  s-to-r lacks capitalization
-|  [gurmukhi](../scriptshifter/tables/data/gurmukhi.yml)  |  Punjabi (Gurmukhi)  |  Y  |  Y  |    |  
-|  [hebrew](../scriptshifter/tables/data/hebrew.yml)  |  Hebrew  |  N  |  Y  |    |  
-|  [hindi_devanagari](../scriptshifter/tables/data/hindi_devanagari.yml)  |  Hindi (Devanagari)  |  Y  |  Y  |  beta  |  
-|  [hiragana](../scriptshifter/tables/data/hiragana.yml)  |  Japanese (Hiragana)  |  Y  |  Y  |    |  
-|  [kalmyk_cyrillic](../scriptshifter/tables/data/kalmyk_cyrillic.yml)  |  Kalmyk (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [kannada](../scriptshifter/tables/data/kannada.yml)  |  Kannada  |  Y  |  Y  |    |  s-to-r lacks capitalization
-|  [kara-kalpak_cyrillic](../scriptshifter/tables/data/kara-kalpak_cyrillic.yml)  |  Kara-Kalpak (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [karachay-balkar_cyrillic](../scriptshifter/tables/data/karachay-balkar_cyrillic.yml)  |  Karachay-Balkar  (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [karelian_cyrillic](../scriptshifter/tables/data/karelian_cyrillic.yml)  |  Karelian  (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [katakana](../scriptshifter/tables/data/katakana.yml)  |  Japanese (Katakana)  |  Y  |  Y  |    |  
-|  [kazakh_cyrillic](../scriptshifter/tables/data/kazakh_cyrillic.yml)  |  Kazakh (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [khakass_cyrillic](../scriptshifter/tables/data/khakass_cyrillic.yml)  |  Khakass (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [khanty_cyrillic](../scriptshifter/tables/data/khanty_cyrillic.yml)  |  Khanty (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [khmer](../scriptshifter/tables/data/khmer.yml)  |  Khmer  |  Y  |  Y  |    |  
-|  [komi_cyrillic](../scriptshifter/tables/data/komi_cyrillic.yml)  |  Komi (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [korean_names](../scriptshifter/tables/data/korean_names.yml)  |  Korean (last + first names only)  |  N  |  Y  |    |  
-|  [korean_nonames](../scriptshifter/tables/data/korean_nonames.yml)  |  Korean  |  N  |  Y  |    |  
-|  [koryak_cyrillic](../scriptshifter/tables/data/koryak_cyrillic.yml)  |  Koryak (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [kurdish](../scriptshifter/tables/data/kurdish.yml)  |  Kurdish  |  Y  |  N  |  stable  |  
-|  [kyrgyz_cyrillic](../scriptshifter/tables/data/kyrgyz_cyrillic.yml)  |  Kyrgyz (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [lithuanian_cyrillic](../scriptshifter/tables/data/lithuanian_cyrillic.yml)  |  Lithuanian (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [macedonian](../scriptshifter/tables/data/macedonian.yml)  |  Macedonian  |  Y  |  Y  |  stable  |  
-|  [malayalam](../scriptshifter/tables/data/malayalam.yml)  |  Malayalam  |  Y  |  Y  |    |  s-to-r lacks capitalization
-|  [manchu](../scriptshifter/tables/data/manchu.yml)  |  Manchu  |  Y  |  Y  |  alpha  |  
-|  [mansi_cyrillic](../scriptshifter/tables/data/mansi_cyrillic.yml)  |  Mansi (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [marathi_devanagari](../scriptshifter/tables/data/marathi_devanagari.yml)  |  Marathi (Devanagari) |  Y  |  Y  |    |  s-to-r lacks capitalization
-|  [mari_cyrillic](../scriptshifter/tables/data/mari_cyrillic.yml)  |  Mari (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [moldovan_cyrillic](../scriptshifter/tables/data/moldovan_cyrillic.yml)  |  Moldovan (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [mongolian_cyrillic](../scriptshifter/tables/data/mongolian_cyrillic.yml)  |  Mongolian (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [mongolian_mongol_bichig](../scriptshifter/tables/data/mongolian_mongol_bichig.yml)  |  Mongolian (Mongol bichig)  |  Y  |  Y  |  stable  |  
-|  [mordvin_cyrillic](../scriptshifter/tables/data/mordvin_cyrillic.yml)  |  Mordvin (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [nenets_cyrillic](../scriptshifter/tables/data/nenets_cyrillic.yml)  |  Nenets (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [nepali_devanagari](../scriptshifter/tables/data/nepali_devanagari.yml)  |  Nepali (Devanagari)  |  Y  |  Y  |    |  
-|  [newari_devanagari](../scriptshifter/tables/data/newari_devanagari.yml)  |  Newari (Devanagari)  |  Y  |  Y  |    |  
-|  [oriya](../scriptshifter/tables/data/oriya.yml)  |  Oriya  |  Y  |  Y  |    |  s-to-r lacks capitalization
-|  [ossetic_cyrillic](../scriptshifter/tables/data/ossetic_cyrillic.yml)  |  Ossetic (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [pali](../scriptshifter/tables/data/pali.yml)  |  Pali  |  Y  |  Y  |    |  
-|  [panjabi_gurmukhi](../scriptshifter/tables/data/panjabi_gurmukhi.yml)  |  Punjabi (Gurmukhi)  |  Y  |  Y  |    |  s-to-r lacks capitalization
-|  [persian](../scriptshifter/tables/data/persian.yml)  |  Persian  |  Y  |  N  |  stable  |  
-|  [prakrit_devanagari](../scriptshifter/tables/data/prakrit_devanagari.yml)  |  Prakrit (Devanagari)  |  Y  |  Y  |    |  
-|  [pulaar](../scriptshifter/tables/data/pulaar.yml)  |  Pulaar (Adlam)  |  Y  |  Y  |  alpha  |  
-|  [pushto](../scriptshifter/tables/data/pushto.yml)  |  Pushto  |  Y  |  N  |  stable  |  
-|  [rajasthani_devanagari](../scriptshifter/tables/data/rajasthani_devanagari.yml)  |  Rajasthani (Devanagari)  |  Y  |  Y  |    |  
-|  [romani_cyrillic](../scriptshifter/tables/data/romani_cyrillic.yml)  |  Romani (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [russian](../scriptshifter/tables/data/russian.yml)  |  Russian  |  Y  |  Y  |  stable  |  
-|  [sanskrit_devanagari](../scriptshifter/tables/data/sanskrit_devanagari.yml)  |  Sanskrit (Devanagari)  |  Y  |  Y  |    |  s-to-r lacks capitalization
-|  [serbian](../scriptshifter/tables/data/serbian.yml)  |  Serbian  |  Y  |  Y  |  stable  |  
-|  [shor_cyrillic](../scriptshifter/tables/data/shor_cyrillic.yml)  |  Shor (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [sinhalese_sinhala](../scriptshifter/tables/data/sinhalese.yml)  |  Sinhalese (Sinhala)  |  Y  |  Y  |    |  s-to-r lacks capitalization
-|  [syriac_cyrillic](../scriptshifter/tables/data/syriac_cyrillic.yml)  |  Syriac (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [tajik_cyrillic](../scriptshifter/tables/data/tajik_cyrillic.yml)  |  Tajik (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [tamil](../scriptshifter/tables/data/tamil.yml)  |  Tamil  |  Y  |  Y  |  beta  |  
-|  [tamil_brahmi](../scriptshifter/tables/data/tamil_brahmi.yml)  |  Tamil Brahmi  |  Y  |  Y  |    |  
-|  [tamil_extended](../scriptshifter/tables/data/tamil_extended.yml)  |  Tamil (extended)  |  Y  |  Y  |    |  
-|  [tatar-kryashen_cyrillic](../scriptshifter/tables/data/tatar-kryashen_cyrillic.yml)  |  Tatar-Kryashen (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [tatar_cyrillic](../scriptshifter/tables/data/tatar_cyrillic.yml)  |  Tatar (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [telugu](../scriptshifter/tables/data/telugu.yml)  |  Telugu  |  Y  |  Y  |    |  s-to-r lacks capitalization
-|  [thai](../scriptshifter/tables/data/thai.yml)  |  Thai  |  N  |  Y  |  beta  |  
-|  [tibetan](../scriptshifter/tables/data/tibetan.yml)  |  Tibetan  |  Y  |  Y  |    |  
-|  [turkmen_cyrillic](../scriptshifter/tables/data/turkmen_cyrillic.yml)  |  Turkmen (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [tuvinian_cyrillic](../scriptshifter/tables/data/tuvinian_cyrillic.yml)  |  Tuvinian (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [udmurt_cyrillic](../scriptshifter/tables/data/udmurt_cyrillic.yml)  |  Udmurt (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [uighur_arabic](../scriptshifter/tables/data/uighur_arabic.yml)  |  Uighur (Arabic)  |  Y  |  Y  |  beta  | 
-|  [uighur_cyrillic](../scriptshifter/tables/data/uighur_cyrillic.yml)  |  Uighur (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [ukrainian](../scriptshifter/tables/data/ukrainian.yml)  |  Ukrainian  |  Y  |  Y  |  stable  |  
-|  [urdu](../scriptshifter/tables/data/urdu.yml)  |  Urdu  |  Y  |  N  |  stable  |  
-|  [uzbek_cyrillic](../scriptshifter/tables/data/uzbek_cyrillic.yml)  |  Uzbek (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [yakut_cyrillic](../scriptshifter/tables/data/yakut_cyrillic.yml)  |  Yakut (Cyrillic)  |  Y  |  Y  |  stable  |  
-|  [yiddish](../scriptshifter/tables/data/yiddish.yml)  |  Yiddish  |  Y  |  Y  |    |  
-|  [yuit_cyrillic](../scriptshifter/tables/data/yuit_cyrillic.yml)  |  Yuit (Cyrillic)  |  Y  |  Y  |  stable  |  
+|	Mapping file |  Script Name  |  Roman-to-script  |  Script-to-roman | Alias of
+|  -------- | ------- | ------- | ------- | ------- |
+
+[abazin_cyrillic](../scriptshifter/tables/data/abazin_cyrillic.yml) | Abazin (Cyrillic) | Y | Y | -
+[abkhaz_cyrillic](../scriptshifter/tables/data/abkhaz_cyrillic.yml) | Abkhaz (Cyrillic) | Y | Y | -
+[adygei_cyrillic](../scriptshifter/tables/data/adygei_cyrillic.yml) | Adygei (Cyrillic) | Y | Y | -
+[altai_cyrillic](../scriptshifter/tables/data/altai_cyrillic.yml) | Altai (Cyrillic) | Y | Y | -
+[amharic](../scriptshifter/tables/data/amharic.yml) | Amharic | - | - | ethiopic_generic
+[ethiopic_generic](../scriptshifter/tables/data/ethiopic_generic.yml) | Ethiopic (Generic) | Y | Y | -
+[arabic](../scriptshifter/tables/data/arabic.yml) | Arabic | Y | Y | -
+[argobba_ethiopic](../scriptshifter/tables/data/argobba_ethiopic.yml) | Argobba (Ethiopic) | - | - | ethiopic_generic
+[armenian](../scriptshifter/tables/data/armenian.yml) | Armenian | Y | Y | -
+[assamese](../scriptshifter/tables/data/assamese.yml) | Assamese | Y | Y | -
+[avaric_cyrillic](../scriptshifter/tables/data/avaric_cyrillic.yml) | Avaric (Cyrillic) | Y | Y | -
+[awadhi_devanagari](../scriptshifter/tables/data/awadhi_devanagari.yml) | Awadhi (Devanagari) | - | - | devanagari_generic
+[devanagari_generic](../scriptshifter/tables/data/devanagari_generic.yml) | Devanagari (Generic) | Y | Y | -
+[azerbaijani_cyrillic](../scriptshifter/tables/data/azerbaijani_cyrillic.yml) | Azerbaijani (Cyrillic) | Y | Y | -
+[balkar_cyrillic](../scriptshifter/tables/data/balkar_cyrillic.yml) | Balkar (Cyrillic) | - | - | cyrillic_generic
+[cyrillic_generic](../scriptshifter/tables/data/cyrillic_generic.yml) | Cyrillic (Generic) | Y | Y | -
+[bashkir_cyrillic](../scriptshifter/tables/data/bashkir_cyrillic.yml) | Bashkir (Cyrillic) | Y | Y | -
+[belarusian](../scriptshifter/tables/data/belarusian.yml) | Belarusian | Y | Y | -
+[bengali](../scriptshifter/tables/data/bengali.yml) | Bengali | Y | Y | -
+[bihari_devanagari](../scriptshifter/tables/data/bihari_devanagari.yml) | Bihari (Devanagari) | - | - | devanagari_generic
+[bodo_bengali](../scriptshifter/tables/data/bodo_bengali.yml) | Bodo (Bengali) | Y | Y | -
+[bodo_devanagari](../scriptshifter/tables/data/bodo_devanagari.yml) | Bodo (Devanagari) | Y | Y | -
+[braj_devanagari](../scriptshifter/tables/data/braj_devanagari.yml) | Braj (Devanagari) | - | - | devanagari_generic
+[bulgarian](../scriptshifter/tables/data/bulgarian.yml) | Bulgarian | Y | Y | -
+[buriat_cyrillic](../scriptshifter/tables/data/buriat_cyrillic.yml) | Buriat (Cyrillic) | Y | Y | -
+[buriat_mongol_bichig](../scriptshifter/tables/data/buriat_mongol_bichig.yml) | Buriat (Mongol bichig) | Y | Y | -
+[burmese](../scriptshifter/tables/data/burmese.yml) | Burmese (Myanmar) | Y | Y | -
+[chechen_cyrillic](../scriptshifter/tables/data/chechen_cyrillic.yml) | Chechen (Cyrillic) | Y | Y | -
+[cherokee](../scriptshifter/tables/data/cherokee.yml) | Cherokee | Y | Y | -
+[chinese](../scriptshifter/tables/data/chinese.yml) | Chinese (Hanzi) | N | Y | -
+[chukchi_cyrillic](../scriptshifter/tables/data/chukchi_cyrillic.yml) | Chukchi (Cyrillic) | Y | Y | -
+[church_slavonic](../scriptshifter/tables/data/church_slavonic.yml) | Church Slavonic | Y | Y | -
+[chuvash_cyrillic](../scriptshifter/tables/data/chuvash_cyrillic.yml) | Chuvash (Cyrillic) | Y | Y | -
+[coptic](../scriptshifter/tables/data/coptic.yml) | Coptic | Y | Y | -
+[dargwa_cyrillic](../scriptshifter/tables/data/dargwa_cyrillic.yml) | Dargwa (Cyrillic) | - | - | cyrillic_generic
+[divehi_thaana](../scriptshifter/tables/data/divehi_thaana.yml) | Divehi (Thaana) | Y | Y | -
+[dogri_devanagari](../scriptshifter/tables/data/dogri_devanagari.yml) | Dogri (Devanagari) | Y | Y | -
+[dungan_cyrillic](../scriptshifter/tables/data/dungan_cyrillic.yml) | Dungan (Cyrillic) | Y | Y | -
+[dzongkha_tibetan](../scriptshifter/tables/data/dzongkha_tibetan.yml) | Dzongkha (Tibetan) | - | - | tibetan
+[tibetan](../scriptshifter/tables/data/tibetan.yml) | Tibetan | Y | Y | -
+[even-evenki_cyrillic](../scriptshifter/tables/data/even-evenki_cyrillic.yml) | Even/Evenki (Cyrillic) | Y | Y | -
+[fula_adlam](../scriptshifter/tables/data/fula_adlam.yml) | Fula (ADLaM) | Y | Y | -
+[gagauz_cyrillic](../scriptshifter/tables/data/gagauz_cyrillic.yml) | Gagauz (Cyrillic) | Y | Y | -
+[georgian](../scriptshifter/tables/data/georgian.yml) | Georgian | Y | Y | -
+[gilyak_cyrillic](../scriptshifter/tables/data/gilyak_cyrillic.yml) | Gilyak (Cyrillic) | - | - | cyrillic_generic
+[glagolitic](../scriptshifter/tables/data/glagolitic.yml) | Glagolitic | Y | Y | -
+[greek_classical](../scriptshifter/tables/data/greek_classical.yml) | Greek (Classical) | Y | Y | -
+[greek_modern](../scriptshifter/tables/data/greek_modern.yml) | Greek (Modern) | Y | Y | -
+[gujarati](../scriptshifter/tables/data/gujarati.yml) | Gujarati | Y | Y | -
+[gurage_ethiopic](../scriptshifter/tables/data/gurage_ethiopic.yml) | Gurage (Ethiopic) | - | - | ethiopic_generic
+[gurmukhi_generic](../scriptshifter/tables/data/gurmukhi_generic.yml) | Gurmukhi (generic) | Y | Y | -
+[hebrew](../scriptshifter/tables/data/hebrew.yml) | Hebrew | N | Y | -
+[hindi](../scriptshifter/tables/data/hindi.yml) | Hindi (Devanagari) | - | - | devanagari_generic
+[ingush_cyrillic](../scriptshifter/tables/data/ingush_cyrillic.yml) | Ingush (Cyrillic) | - | - | cyrillic_generic
+[inuit_cyrillic](../scriptshifter/tables/data/inuit_cyrillic.yml) | Inuit (Cyrillic) | - | - | cyrillic_generic
+[inuktitut](../scriptshifter/tables/data/inuktitut.yml) | Inuktitut | Y | Y | -
+[kabardian_cyrillic](../scriptshifter/tables/data/kabardian_cyrillic.yml) | Kabardian (Cyrillic) | - | - | cyrillic_generic
+[kalmyk_cyrillic](../scriptshifter/tables/data/kalmyk_cyrillic.yml) | Kalmyk (Cyrillic) | Y | Y | -
+[kalmyk_tod](../scriptshifter/tables/data/kalmyk_tod.yml) | Kalmyk (Tod) | Y | Y | -
+[kannada](../scriptshifter/tables/data/kannada.yml) | Kannada | Y | Y | -
+[kara-kalpak_cyrillic](../scriptshifter/tables/data/kara-kalpak_cyrillic.yml) | Kara-Kalpak (Cyrillic) | - | - | cyrillic_generic
+[karachay-balkar_cyrillic](../scriptshifter/tables/data/karachay-balkar_cyrillic.yml) | Karachay-Balkar  (Cyrillic) | Y | Y | -
+[karelian_cyrillic](../scriptshifter/tables/data/karelian_cyrillic.yml) | Karelian  (Cyrillic) | Y | Y | -
+[kazakh_cyrillic](../scriptshifter/tables/data/kazakh_cyrillic.yml) | Kazakh (Cyrillic) | Y | Y | -
+[khakass_cyrillic](../scriptshifter/tables/data/khakass_cyrillic.yml) | Khakass (Cyrillic) | Y | Y | -
+[khanty_cyrillic](../scriptshifter/tables/data/khanty_cyrillic.yml) | Khanty (Cyrillic) | Y | Y | -
+[khmer](../scriptshifter/tables/data/khmer.yml) | Khmer | Y | Y | -
+[komi_cyrillic](../scriptshifter/tables/data/komi_cyrillic.yml) | Komi (Cyrillic) | Y | Y | -
+[komi-permyak_cyrillic](../scriptshifter/tables/data/komi-permyak_cyrillic.yml) | Komi-Permyak (Cyrillic) | Y | Y | -
+[konkani_devanagari](../scriptshifter/tables/data/konkani_devanagari.yml) | Konkani (Devanagari) | - | - | devanagari_generic
+[konkani_kannada](../scriptshifter/tables/data/konkani_kannada.yml) | Konkani (Kannada) | - | - | kannada
+[korean_names](../scriptshifter/tables/data/korean_names.yml) | Korean (last + first names only) | N | Y | -
+[korean_nonames](../scriptshifter/tables/data/korean_nonames.yml) | Korean | N | Y | -
+[koryak_cyrillic](../scriptshifter/tables/data/koryak_cyrillic.yml) | Koryak (Cyrillic) | Y | Y | -
+[kumyk_cyrillic](../scriptshifter/tables/data/kumyk_cyrillic.yml) | Kumyk (Cyrillic) | - | - | cyrillic_generic
+[kurdish_arabic](../scriptshifter/tables/data/kurdish_arabic.yml) | Kurdish (Arabic) | Y | N | -
+[kurdish_cyrillic](../scriptshifter/tables/data/kurdish_cyrillic.yml) | Kurdish (Cyrillic) | Y | Y | -
+[kyrgyz_cyrillic](../scriptshifter/tables/data/kyrgyz_cyrillic.yml) | Kyrgyz (Cyrillic) | Y | Y | -
+[lak_cyrillic](../scriptshifter/tables/data/lak_cyrillic.yml) | Lak (Cyrillic) | - | - | cyrillic_generic
+[lahnda_gurmukhi](../scriptshifter/tables/data/lahnda_gurmukhi.yml) | Lahnda (Gurmukhi) | - | - | gurmukhi_generic
+[lepcha](../scriptshifter/tables/data/lepcha.yml) | Lepcha | Y | Y | -
+[lezghian_cyrillic](../scriptshifter/tables/data/lezghian_cyrillic.yml) | Lezghian (Cyrillic) | - | - | cyrillic_generic
+[limbu](../scriptshifter/tables/data/limbu.yml) | Limbu | Y | Y | -
+[lithuanian_cyrillic](../scriptshifter/tables/data/lithuanian_cyrillic.yml) | Lithuanian (Cyrillic) | Y | Y | -
+[macedonian](../scriptshifter/tables/data/macedonian.yml) | Macedonian | Y | Y | -
+[maithili_devanagari](../scriptshifter/tables/data/maithili_devanagari.yml) | Maithili (Devanagari) | - | - | devanagari_generic
+[malayalam](../scriptshifter/tables/data/malayalam.yml) | Malayalam | Y | Y | -
+[manchu](../scriptshifter/tables/data/manchu.yml) | Manchu | Y | Y | -
+[manipuri_bengali](../scriptshifter/tables/data/manipuri_bengali.yml) | Manipuri (Bengali) | Y | Y | -
+[manipuri_meitei](../scriptshifter/tables/data/manipuri_meitei.yml) | Manipuri (Meitei) | Y | Y | -
+[mansi_cyrillic](../scriptshifter/tables/data/mansi_cyrillic.yml) | Mansi (Cyrillic) | Y | Y | -
+[marathi_devanagari](../scriptshifter/tables/data/marathi_devanagari.yml) | Marathi (Devanagari) | Y | Y | -
+[mari_cyrillic](../scriptshifter/tables/data/mari_cyrillic.yml) | Mari (Cyrillic) | - | - | cyrillic_generic
+[moldovan_cyrillic](../scriptshifter/tables/data/moldovan_cyrillic.yml) | Moldovan (Cyrillic) | Y | Y | -
+[mongolian_cyrillic](../scriptshifter/tables/data/mongolian_cyrillic.yml) | Mongolian (Cyrillic) | Y | Y | -
+[mongolian_mongol_bichig](../scriptshifter/tables/data/mongolian_mongol_bichig.yml) | Mongolian (Mongol bichig) | Y | Y | -
+[montenegrin_cyrillic](../scriptshifter/tables/data/montenegrin_cyrillic.yml) | Montenegrin (Cyrillic) | Y | Y | -
+[mordvin_cyrillic](../scriptshifter/tables/data/mordvin_cyrillic.yml) | Mordvin (Cyrillic) | Y | Y | -
+[moroccan_tamazight](../scriptshifter/tables/data/moroccan_tamazight.yml) | Moroccan Tamazight | - | - | tifinagh_generic
+[tifinagh_generic](../scriptshifter/tables/data/tifinagh_generic.yml) | Tifinagh (Generic) | Y | Y | -
+[nanai_cyrillic](../scriptshifter/tables/data/nanai_cyrillic.yml) | Nanai (Cyrillic) | - | - | cyrillic_generic
+[nenets_cyrillic](../scriptshifter/tables/data/nenets_cyrillic.yml) | Nenets (Cyrillic) | Y | Y | -
+[nepali_devanagari](../scriptshifter/tables/data/nepali_devanagari.yml) | Nepali (Devanagari) | - | - | devanagari_generic
+[newari_devanagari](../scriptshifter/tables/data/newari_devanagari.yml) | Newari (Devanagari) | - | - | devanagari_generic
+[nivkh_cyrillic](../scriptshifter/tables/data/nivkh_cyrillic.yml) | Nivkh (Cyrillic) | - | - | cyrillic_generic
+[nogai_cyrillic](../scriptshifter/tables/data/nogai_cyrillic.yml) | Nogai (Cyrillic) | - | - | cyrillic_generic
+[odia](../scriptshifter/tables/data/odia.yml) | Odia | Y | Y | -
+[ossetic_cyrillic](../scriptshifter/tables/data/ossetic_cyrillic.yml) | Ossetic (Cyrillic) | Y | Y | -
+[pahari_devanagari](../scriptshifter/tables/data/pahari_devanagari.yml) | Pahari (Devanagari) | - | - | devanagari_generic
+[pali_bengali](../scriptshifter/tables/data/pali_bengali.yml) | Pali (Bengali) | - | - | bengali
+[pali_devanagari](../scriptshifter/tables/data/pali_devanagari.yml) | Pali (Devanagari) | - | - | devanagari_generic
+[pali_sinhala](../scriptshifter/tables/data/pali_sinhala.yml) | Pali (Sinhala) | - | - | sinhala
+[sinhala](../scriptshifter/tables/data/sinhala.yml) | Sinhala | Y | Y | -
+[panjabi_gurmukhi](../scriptshifter/tables/data/panjabi_gurmukhi.yml) | Panjabi (Gurmukhi) | Y | Y | -
+[permyak_cyrillic](../scriptshifter/tables/data/permyak_cyrillic.yml) | Permyak (Cyrillic) | - | - | komi-permyak_cyrillic
+[persian](../scriptshifter/tables/data/persian.yml) | Persian | Y | N | -
+[prakrit_devanagari](../scriptshifter/tables/data/prakrit_devanagari.yml) | Prakrit (Devanagari) | Y | Y | -
+[pushto](../scriptshifter/tables/data/pushto.yml) | Pushto | Y | N | -
+[rajasthani_devanagari](../scriptshifter/tables/data/rajasthani_devanagari.yml) | Rajasthani (Devanagari) | - | - | devanagari_generic
+[romani_cyrillic](../scriptshifter/tables/data/romani_cyrillic.yml) | Romani (Cyrillic) | - | - | cyrillic_generic
+[romanian_cyrillic](../scriptshifter/tables/data/romanian_cyrillic.yml) | Romanian (Cyrillic) | Y | Y | -
+[russian](../scriptshifter/tables/data/russian.yml) | Russian | Y | Y | -
+[sami_cyrillic](../scriptshifter/tables/data/sami_cyrillic.yml) | Sami (Cyrillic) | Y | Y | -
+[sanskrit_devanagari](../scriptshifter/tables/data/sanskrit_devanagari.yml) | Sanskrit (Devanagari) | Y | Y | -
+[santali_ol_chiki](../scriptshifter/tables/data/santali_ol_chiki.yml) | Santali (Ol chiki) | Y | Y | -
+[selkup_cyrillic](../scriptshifter/tables/data/selkup_cyrillic.yml) | Selkup (Cyrillic) | Y | Y | -
+[serbian](../scriptshifter/tables/data/serbian.yml) | Serbian | Y | Y | -
+[shor_cyrillic](../scriptshifter/tables/data/shor_cyrillic.yml) | Shor (Cyrillic) | Y | Y | -
+[sindhi_arabic](../scriptshifter/tables/data/sindhi_arabic.yml) | Sindhi (Arabic) | Y | N | -
+[sindhi_gurmukhi](../scriptshifter/tables/data/sindhi_gurmukhi.yml) | Sindhi (Gurmukhi) | - | - | gurmukhi_generic
+[syriac_cyrillic](../scriptshifter/tables/data/syriac_cyrillic.yml) | Syriac (Cyrillic) | Y | Y | -
+[tabasaran_cyrillic](../scriptshifter/tables/data/tabasaran_cyrillic.yml) | Tabasaran (Cyrillic) | - | - | cyrillic_generic
+[tajik_cyrillic](../scriptshifter/tables/data/tajik_cyrillic.yml) | Tajik (Cyrillic) | Y | Y | -
+[tamashek](../scriptshifter/tables/data/tamashek.yml) | Tamashek | Y | Y | -
+[tamazight_moroccan](../scriptshifter/tables/data/tamazight_moroccan.yml) | Tamazight (Moroccan) | - | - | tifinagh_generic
+[tamil](../scriptshifter/tables/data/tamil.yml) | Tamil | Y | Y | -
+[tamil_brahmi](../scriptshifter/tables/data/tamil_brahmi.yml) | Tamil Brahmi | Y | Y | -
+[tamil_extended](../scriptshifter/tables/data/tamil_extended.yml) | Tamil (extended) | Y | Y | -
+[tat_cyrillic](../scriptshifter/tables/data/tat_cyrillic.yml) | Tat (Cyrillic) | - | - | cyrillic_generic
+[tatar_cyrillic](../scriptshifter/tables/data/tatar_cyrillic.yml) | Tatar (Cyrillic) | Y | Y | -
+[tatar-kryashen_cyrillic](../scriptshifter/tables/data/tatar-kryashen_cyrillic.yml) | Tatar-Kryashen (Cyrillic) | Y | Y | -
+[telugu](../scriptshifter/tables/data/telugu.yml) | Telugu | Y | Y | -
+[thai](../scriptshifter/tables/data/thai.yml) | Thai | N | Y | -
+[tibetan_2015_r2r](../scriptshifter/tables/data/tibetan_2015_r2r.yml) | Tibetan (ñ,ṅ,ś,ź to ny,ng,sh,zh only) | Y | N | -
+[tigre_ethiopic](../scriptshifter/tables/data/tigre_ethiopic.yml) | Tigre (Ethiopic) | - | - | ethiopic_generic
+[tigrinya_ethiopic](../scriptshifter/tables/data/tigrinya_ethiopic.yml) | Tigrinya (Ethiopic) | - | - | ethiopic_generic
+[turkmen_cyrillic](../scriptshifter/tables/data/turkmen_cyrillic.yml) | Turkmen (Cyrillic) | Y | Y | -
+[tuvinian_cyrillic](../scriptshifter/tables/data/tuvinian_cyrillic.yml) | Tuvinian (Cyrillic) | - | - | cyrillic_generic
+[udekhe_cyrillic](../scriptshifter/tables/data/udekhe_cyrillic.yml) | Udekhe (Cyrillic) | - | - | cyrillic_generic
+[udmurt_cyrillic](../scriptshifter/tables/data/udmurt_cyrillic.yml) | Udmurt (Cyrillic) | Y | Y | -
+[uighur_arabic](../scriptshifter/tables/data/uighur_arabic.yml) | Uighur (Arabic) | Y | Y | -
+[uighur_cyrillic](../scriptshifter/tables/data/uighur_cyrillic.yml) | Uighur (Cyrillic) | Y | Y | -
+[ukrainian](../scriptshifter/tables/data/ukrainian.yml) | Ukrainian | Y | Y | -
+[urdu](../scriptshifter/tables/data/urdu.yml) | Urdu | Y | N | -
+[uzbek_cyrillic](../scriptshifter/tables/data/uzbek_cyrillic.yml) | Uzbek (Cyrillic) | Y | Y | -
+[yakut_cyrillic](../scriptshifter/tables/data/yakut_cyrillic.yml) | Yakut (Cyrillic) | Y | Y | -
+[yiddish](../scriptshifter/tables/data/yiddish.yml) | Yiddish | Y | Y | -
+[yuit_cyrillic](../scriptshifter/tables/data/yuit_cyrillic.yml) | Yuit (Cyrillic) | Y | Y | -

--- a/doc/supported_scripts_template.md
+++ b/doc/supported_scripts_template.md
@@ -1,0 +1,14 @@
+## Supported Scripts/Mappings in ScriptShifter
+
+Below are the supported scripts, and supported directionality of those scripts, in ScriptShifter.
+
+The "status" value may be *stable*, *beta*, *alpha*, or blank (i.e. empty).  "Stable" means the mapping 
+is maintained within ScriptShifter, has been tested, and is in use.  "Beta" or "alpha" represent mappings
+that are in some form of development and/or testing, with "beta" being more mature than "alpha" in this
+regard.  If the column is 'blank,' transliteration of the script is available in ScriptShifter from a
+third-party library.
+
+
+|	Mapping file |  Script Name  |  Roman-to-script  |  Script-to-roman | Alias of
+|  -------- | ------- | ------- | ------- | ------- |
+

--- a/doc/supported_scripts_template.md
+++ b/doc/supported_scripts_template.md
@@ -2,12 +2,17 @@
 
 Below are the supported scripts, and supported directionality of those scripts, in ScriptShifter.
 
+<<<<<<< Updated upstream
 The "status" value may be *stable*, *beta*, *alpha*, or blank (i.e. empty).  "Stable" means the mapping 
 is maintained within ScriptShifter, has been tested, and is in use.  "Beta" or "alpha" represent mappings
 that are in some form of development and/or testing, with "beta" being more mature than "alpha" in this
 regard.  If the column is 'blank,' transliteration of the script is available in ScriptShifter from a
 third-party library.
 
+=======
+"Alias of" means that the script table is the same as the table indicated, only
+under a different name.
+>>>>>>> Stashed changes
 
 |	Mapping file |  Script Name  |  Roman-to-script  |  Script-to-roman | Alias of
 |  -------- | ------- | ------- | ------- | ------- |

--- a/doc/supported_scripts_template.md
+++ b/doc/supported_scripts_template.md
@@ -2,17 +2,8 @@
 
 Below are the supported scripts, and supported directionality of those scripts, in ScriptShifter.
 
-<<<<<<< Updated upstream
-The "status" value may be *stable*, *beta*, *alpha*, or blank (i.e. empty).  "Stable" means the mapping 
-is maintained within ScriptShifter, has been tested, and is in use.  "Beta" or "alpha" represent mappings
-that are in some form of development and/or testing, with "beta" being more mature than "alpha" in this
-regard.  If the column is 'blank,' transliteration of the script is available in ScriptShifter from a
-third-party library.
-
-=======
 "Alias of" means that the script table is the same as the table indicated, only
 under a different name.
->>>>>>> Stashed changes
 
 |	Mapping file |  Script Name  |  Roman-to-script  |  Script-to-roman | Alias of
 |  -------- | ------- | ------- | ------- | ------- |

--- a/scriptshifter/hooks/korean/romanizer.py
+++ b/scriptshifter/hooks/korean/romanizer.py
@@ -147,17 +147,10 @@ def _romanize_names(src, options):
     warnings = []
     # Normalize to precomposed characters.
     src = normalize("NFC", src)
-
-    if "," in src and "·" in src:
-        warnings.append(
-                "both commas and middle dots are being used to separate "
-                "names. Only one of the two types should be used, or "
-                "unexpected results may occur.")
-
-    kor_ls = src.split(",") if "," in src else src.split("·")
+    kor_ls = src.split("·")
 
     for kor in kor_ls:
-        rom, _warnings = _romanize_name(kor.strip(), options)
+        rom, _warnings = _romanize_name(kor.strip(ALL_PUNCT_STR), options)
         rom_ls.append(rom)
 
         warnings.extend(_warnings)


### PR DESCRIPTION
@thisismattmiller @rrroche this adds a script to automate the generation of the doc page that lists the supported languages, by reading the configuration. Since it's easy for that documentation to fall out of sync, this tool should make it easier and less error-prone to maintain. 

Note that I removed "status" and "remarks" for now. Neither one is information we have in the configuration. I added "alias of" which I think is an important data point. If you think we really need "status", I can add the version number (not indexed yet but present in the config) which, if starting with 0., indicates a beta release. 